### PR TITLE
Fix #177: Add version indicators to demo footers

### DIFF
--- a/unified-demos/demo1/index.html
+++ b/unified-demos/demo1/index.html
@@ -799,6 +799,7 @@
             </div>
             <div class="footer-right">
                 <div class="build-number" id="buildNumber">BUILD v1.2.0-demo1</div>
+                <div style="color: var(--primary-color); font-weight: 500;">Demo v2.0.1</div>
             </div>
         </footer>
     </div>

--- a/unified-demos/demo2/index.html
+++ b/unified-demos/demo2/index.html
@@ -1069,5 +1069,14 @@
         `;
         document.head.appendChild(style);
     </script>
+
+    <!-- Footer with version info -->
+    <div style="position: fixed; bottom: 0; left: 0; right: 0; background: var(--fluent-neutral-bg-secondary); border-top: 1px solid var(--fluent-border-primary); padding: 8px 20px; display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: var(--fluent-text-tertiary);">
+        <div>© 2025 Cultivate Learning, University of Washington</div>
+        <div style="display: flex; gap: 15px;">
+            <span>BUILD v1.2.0-demo2</span>
+            <span style="color: var(--fluent-brand-primary); font-weight: 500;">Demo v2.0.1</span>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Added version indicators to both demo1 and demo2 footers
- Shows "Demo v2.0.1" to help track deployments

## Changes
- ✅ Added version indicator to demo1 footer
- ✅ Added complete footer with version info to demo2
- ✅ Maintains consistent styling with existing design

## Testing
- [ ] Version displays correctly in demo1 footer
- [ ] Version displays correctly in demo2 footer
- [ ] Footer doesn't interfere with page content

## Screenshots
Will be visible after deployment to verify the version numbers appear correctly.

Fixes #177

🤖 Generated with [Claude Code](https://claude.ai/code)