### PR TITLE
feat: Add Demo 3 card to main landing page

### DIFF
--- a/unified-demos/index.html
+++ b/unified-demos/index.html
@@ -408,6 +408,25 @@
                     </div>
                     <button class="launch-button">Launch Demo 2</button>
                 </a>
+
+                <!-- Demo 3 Card -->
+                <a href="https://victorious-meadow-0b2278a10.1.azurestaticapps.net/demo3/" class="demo-card">
+                    <div class="card-header-demo">
+                        <div class="card-number">3</div>
+                        <h2>Multi-Video Analysis Platform</h2>
+                    </div>
+                    <p class="description">
+                        Comprehensive analysis of 25 Cultivate Learning classroom videos with expert annotations.
+                        Compare ML predictions against ground truth with precision, recall, and F1 metrics.
+                    </p>
+                    <div class="features">
+                        <span class="feature-tag">25 Videos</span>
+                        <span class="feature-tag">Ground Truth</span>
+                        <span class="feature-tag">Confusion Matrix</span>
+                        <span class="feature-tag">Analytics</span>
+                    </div>
+                    <button class="launch-button">Launch Demo 3</button>
+                </a>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Added Multi-Video Analysis Platform card to the main landing page demos grid
- Links directly to Azure SWA: https://victorious-meadow-0b2278a10.1.azurestaticapps.net/demo3/
- Feature tags: 25 Videos, Ground Truth, Confusion Matrix, Analytics

## Test plan
- [ ] Verify Demo 3 card appears on landing page
- [ ] Verify link navigates to Demo 3
- [ ] Verify card styling matches Demo 1 and Demo 2

@claude and @codex please review this pr

Generated with [Claude Code](https://claude.com/claude-code)