### PR TITLE
fix(demo3): Fix video storage URL and default to dark mode

### DIFF
--- a/unified-demos/demo3/app.js
+++ b/unified-demos/demo3/app.js
@@ -119,7 +119,7 @@ const Config = {
     },
 
     // Azure Blob Storage for video fallback
-    azureBlobBase: 'https://cultivatemlstorage.blob.core.windows.net/videos',
+    azureBlobBase: 'https://cultivatemlvideos.blob.core.windows.net/videos',
 
     // LocalStorage keys
     storageKeys: {

--- a/unified-demos/demo3/index.html
+++ b/unified-demos/demo3/index.html
@@ -703,7 +703,17 @@
         }
     </style>
 </head>
-<body data-theme="light">
+<body data-theme="dark">
+    <!-- Demo 3 defaults to dark mode -->
+    <script>
+        // Set dark mode as default for Demo 3 if no preference saved
+        if (!localStorage.getItem('theme')) {
+            localStorage.setItem('theme', 'dark');
+        }
+        // Apply saved theme immediately to prevent flash
+        document.body.setAttribute('data-theme', localStorage.getItem('theme') || 'dark');
+    </script>
+
     <!-- Password Protection Overlay -->
     <div id="passwordOverlay" class="password-overlay">
         <div class="password-box">


### PR DESCRIPTION
## Summary
- Changed Azure Blob URL from `cultivatemlstorage` to `cultivatemlvideos` (matches CSP policy)
- Set Demo 3 to default to dark mode for better viewing of educational content
- Apply theme immediately on page load to prevent flash of unstyled content

## Test plan
- [ ] Verify videos load without CSP violation
- [ ] Verify Demo 3 starts in dark mode on fresh browser
- [ ] Verify theme toggle still works correctly

@claude and @codex please review this pr

Generated with [Claude Code](https://claude.com/claude-code)