### PR TITLE
fix(demo3): Fix video URL double extension and component exports

### DIFF
--- a/unified-demos/demo3/app.js
+++ b/unified-demos/demo3/app.js
@@ -345,9 +345,15 @@ function getVideoSourceUrl(video) {
     }
 
     // Construct Azure Blob Storage URL
-    const filename = encodeURIComponent(video.filename);
-    const extension = video.file_info?.local_path?.split('.').pop() || 'mp4';
+    // Check if filename already has an extension
+    const hasExtension = /\.(mp4|mov|avi|webm)$/i.test(video.filename);
+    const filename = encodeURIComponent(video.filename.trim());
 
+    if (hasExtension) {
+        return `${Config.azureBlobBase}/${filename}`;
+    }
+
+    const extension = video.file_info?.local_path?.split('.').pop() || 'mp4';
     return `${Config.azureBlobBase}/${filename}.${extension}`;
 }
 

--- a/unified-demos/demo3/components/analytics.js
+++ b/unified-demos/demo3/components/analytics.js
@@ -12,7 +12,7 @@
  * Warren's Vision: Professional, data-driven, fully functional analytics
  */
 
-class AnalyticsDashboard {
+export class AnalyticsDashboard {
     constructor(containerId, options = {}) {
         this.containerId = containerId;
         this.container = null;

--- a/unified-demos/demo3/components/question-panel.js
+++ b/unified-demos/demo3/components/question-panel.js
@@ -11,7 +11,7 @@
  * - Request cancellation support
  */
 
-class QuestionPanel {
+export class QuestionPanel {
     constructor(containerSelector) {
         this.container = document.querySelector(containerSelector);
         this.initialized = false;


### PR DESCRIPTION
## Summary
Bug fixes for Demo 3:
- Fixed double `.mp4` extension when filename already includes extension (e.g., `Book about Flowers SOM SUBS .mp4.mp4`)
- Added ES6 `export` to QuestionPanel and AnalyticsDashboard components
- Components now load correctly via dynamic imports

## Issues Resolved
- `QuestionPanel not available` error
- `AnalyticsDashboard not available` error
- Video 404 errors for files with `.mp4` in filename

## Test plan
- [ ] Verify QuestionPanel loads and displays questions
- [ ] Verify AnalyticsDashboard loads and shows metrics
- [ ] Verify "Book about Flowers" video loads without 404

@claude and @codex please review this pr

Generated with [Claude Code](https://claude.com/claude-code)